### PR TITLE
Fixed XXE (XML External Entity)

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/validator/XmlValidatorManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/validator/XmlValidatorManager.java
@@ -123,6 +123,15 @@ public class XmlValidatorManager implements ValidatorManager {
     final DocumentBuilderFactory docBuilderFactory =
         DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = null;
+
+    docBuilderFactory.setNamespaceAware(true);
+    docBuilderFactory.setXIncludeAware(false);
+    docBuilderFactory.setExpandEntityReferences(false);
+    docBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    docBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    docBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    docBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    
     try {
       builder = docBuilderFactory.newDocumentBuilder();
     } catch (final ParserConfigurationException e) {

--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -110,6 +110,15 @@ public class XmlUserManager implements UserManager {
     final DocumentBuilderFactory docBuilderFactory =
         DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = null;
+
+    docBuilderFactory.setNamespaceAware(true);
+    docBuilderFactory.setXIncludeAware(false);
+    docBuilderFactory.setExpandEntityReferences(false);
+    docBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    docBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    docBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    docBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
     try {
       builder = docBuilderFactory.newDocumentBuilder();
     } catch (final ParserConfigurationException e) {


### PR DESCRIPTION
:gear: **Fix:**

For: https://github.com/azkaban/azkaban/issues/2478

This is a really interesting vulnerability especially because it's on a Java XML Parser. It started a long ago that security researchers started poking with different kinds of Java XML Parsers like `DocumentBuilderFactory`, `TransformerFactory`, `SAXParserFactory` etc for XXEs (`XML External Entity`).

The fix is however usually mitigated by the following snippet:
```java
DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
```

But it turns out `FEATURE_SECURE_PROCESSING` alone seems not to be secure enough.

:spiral_notepad: **Source:** [Black Hat Paper on XXEs in Java Parsers](https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf)

[OWASP](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#TransformerFactory) recommends `ACCESS_EXTERNAL_DTD` and `ACCESS_EXTERNAL_STYLESHEET` but it's mainly centered for the `TransformerFactory` Parser. As it's implemented in `DocumentBuilderFactory` and has been used in other functions as well, I wrote a fix for it rather than switching to any other parsers.

Thanks to [this gist](https://gist.github.com/AlainODea/1779a7c6a26a5c135280bc9b3b71868f). :raised_hands: 

**Fixed on Both:**
- _XmlUserManager.java_ - https://github.com/418sec/azkaban/commit/c50f27def4488015e3851a9bee23de32ea5e48de
- _XmlValidatorManager.java_ - https://github.com/418sec/azkaban/commit/98c7f0fd0d84dfbf428a6dedd22171c8a46e40bb

:books: **Reference:**
- https://stackoverflow.com/questions/40649152/how-to-prevent-xxe-attack
- https://gist.github.com/AlainODea/1779a7c6a26a5c135280bc9b3b71868f
- https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
- https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
- https://stackoverflow.com/questions/30710966/how-do-i-globally-configure-xml-parsers-against-xxe
- https://dev.to/brianverm/configure-your-java-xml-parsers-to-prevent-xxe-213c

<hr>

### :v: **Fixed!**

<hr>